### PR TITLE
fix misleading error displayed in console

### DIFF
--- a/SpecRunner.html
+++ b/SpecRunner.html
@@ -11,10 +11,6 @@
     <script src="jasmine/jasmine-2.8.0/jasmine-html.js"></script>
     <script src="jasmine/jasmine-2.8.0/boot.js"></script>
 
-
-    <script src="src/index.js"></script>
-
-    
     <!--  Iterations 1 - 8 -->    
     <script src="src/chronometer.js"></script>
     <script src="tests/chronometer.spec.js"></script>


### PR DESCRIPTION
by removing an unneeded dependency
that tries to create a `Chronometer` instance
while the class is still not available (because defined later)

Error message: "Uncaught ReferenceError: Chronometer is not defined"